### PR TITLE
Add usage("message") as policy parameter to def()

### DIFF
--- a/cpptcl.cc
+++ b/cpptcl.cc
@@ -97,9 +97,9 @@ void details::set_result(Tcl_Interp *interp, void *p) {
 
 void details::set_result(Tcl_Interp *interp, object const &o) { Tcl_SetObjResult(interp, o.get_object()); }
 
-void details::check_params_no(int objc, int required) {
+void details::check_params_no(int objc, int required, const std::string &message) {
 	if (objc < required) {
-		throw tcl_error("Too few arguments.");
+		throw tcl_error(message);
 	}
 }
 
@@ -107,10 +107,10 @@ object details::get_var_params(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv
 	object o;
 
 	if (pol.variadic_) {
-		check_params_no(objc, from);
+		check_params_no(objc, from, pol.usage_);
 		o.assign(objv + from, objv + objc);
 	} else {
-		check_params_no(objc, from + 1);
+		check_params_no(objc, from + 1, pol.usage_);
 		o.assign(objv[from]);
 	}
 
@@ -355,11 +355,18 @@ policies &policies::variadic() {
 	return *this;
 }
 
+policies &policies::usage(string const &message) {
+	usage_ = message;
+	return *this;
+}
+
 policies Tcl::factory(string const &name) { return policies().factory(name); }
 
 policies Tcl::sink(int index) { return policies().sink(index); }
 
 policies Tcl::variadic() { return policies().variadic(); }
+
+policies Tcl::usage(string const &message) { return policies().usage(message); }
 
 class_handler_base::class_handler_base() {
 	// default policies for the -delete command

--- a/cpptcl.cc
+++ b/cpptcl.cc
@@ -356,7 +356,7 @@ policies &policies::variadic() {
 }
 
 policies &policies::usage(string const &message) {
-	usage_ = message;
+	usage_ = std::string("Usage: ") + message;
 	return *this;
 }
 

--- a/cpptcl/cpptcl.h
+++ b/cpptcl/cpptcl.h
@@ -43,7 +43,7 @@ class tcl_error : public std::runtime_error {
 // call policies
 
 struct policies {
-	policies() : variadic_(false) {}
+	policies() : variadic_(false), usage_("Too few arguments.") {}
 
 	policies &factory(std::string const &name);
 
@@ -52,15 +52,19 @@ struct policies {
 
 	policies &variadic();
 
+	policies &usage(std::string const &message);
+
 	std::string factory_;
 	std::vector<int> sinks_;
 	bool variadic_;
+	std::string usage_;
 };
 
 // syntax short-cuts
 policies factory(std::string const &name);
 policies sink(int index);
 policies variadic();
+policies usage(std::string const &message);
 
 class interpreter;
 class object;
@@ -101,7 +105,7 @@ void set_result(Tcl_Interp *interp, object const &o);
 
 // helper for checking for required number of parameters
 // (throws tcl_error when not met)
-void check_params_no(int objc, int required);
+void check_params_no(int objc, int required, const std::string &message);
 
 // helper for gathering optional params in variadic functions
 object get_var_params(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], int from, policies const &pol);
@@ -151,7 +155,7 @@ template <class C> class class_handler : public class_handler_base {
 		C *p = static_cast<C *>(pv);
 
 		if (objc < 2) {
-			throw tcl_error("Too few arguments.");
+			throw tcl_error(pol.usage_);
 		}
 
 		std::string methodName(Tcl_GetString(objv[1]));

--- a/cpptcl/details/callbacks.h
+++ b/cpptcl/details/callbacks.h
@@ -19,7 +19,7 @@ template <typename R> class callback0 : public callback_base {
   public:
 	callback0(functor_type f) : f_(f) {}
 
-	virtual void invoke(Tcl_Interp *interp, int, Tcl_Obj *CONST[], policies const &) { dispatch<R>::do_dispatch(interp, f_); }
+	virtual void invoke(Tcl_Interp *interp, int, Tcl_Obj *CONST[], policies const &pol) { dispatch<R>::do_dispatch(interp, f_); }
 
   private:
 	functor_type f_;
@@ -31,8 +31,8 @@ template <typename R, typename T1> class callback1 : public callback_base {
   public:
 	callback1(functor_type f) : f_(f) {}
 
-	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 2);
+	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 2, pol.usage_);
 		tcl_cast_by_reference<T1> byRef1;
 		dispatch<R>::template do_dispatch<T1>(interp, f_, tcl_cast<T1>::from(interp, objv[1], byRef1.value));
 	}
@@ -47,8 +47,8 @@ template <typename R, typename T1, typename T2> class callback2 : public callbac
   public:
 	callback2(functor_type f) : f_(f) {}
 
-	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 3);
+	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 3, pol.usage_);
 		tcl_cast_by_reference<T1> byRef1;
 		tcl_cast_by_reference<T2> byRef2;
 
@@ -65,8 +65,8 @@ template <typename R, typename T1, typename T2, typename T3> class callback3 : p
   public:
 	callback3(functor_type f) : f_(f) {}
 
-	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 4);
+	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 4, pol.usage_);
 		tcl_cast_by_reference<T1> byRef1;
 		tcl_cast_by_reference<T2> byRef2;
 		tcl_cast_by_reference<T3> byRef3;
@@ -84,8 +84,8 @@ template <typename R, typename T1, typename T2, typename T3, typename T4> class 
   public:
 	callback4(functor_type f) : f_(f) {}
 
-	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 5);
+	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 5, pol.usage_);
 		tcl_cast_by_reference<T1> byRef1;
 		tcl_cast_by_reference<T2> byRef2;
 		tcl_cast_by_reference<T3> byRef3;
@@ -109,8 +109,8 @@ template <typename R, typename T1, typename T2, typename T3, typename T4, typena
 	tcl_cast_by_reference<T4> byRef4;
 	tcl_cast_by_reference<T5> byRef5;
 
-	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 6);
+	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 6, pol.usage_);
 
 		dispatch<R>::template do_dispatch<T1, T2, T3, T4, T5>(interp, f_, tcl_cast<T1>::from(interp, objv[1], byRef1.value), tcl_cast<T2>::from(interp, objv[2], byRef2.value), tcl_cast<T3>::from(interp, objv[3], byRef3.value), tcl_cast<T4>::from(interp, objv[4], byRef4.value), tcl_cast<T5>::from(interp, objv[5], byRef5.value));
 	}
@@ -125,8 +125,8 @@ template <typename R, typename T1, typename T2, typename T3, typename T4, typena
   public:
 	callback6(functor_type f) : f_(f) {}
 
-	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 7);
+	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 7, pol.usage_);
 		tcl_cast_by_reference<T1> byRef1;
 		tcl_cast_by_reference<T2> byRef2;
 		tcl_cast_by_reference<T3> byRef3;
@@ -147,8 +147,8 @@ template <typename R, typename T1, typename T2, typename T3, typename T4, typena
   public:
 	callback7(functor_type f) : f_(f) {}
 
-	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 8);
+	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 8, pol.usage_);
 		tcl_cast_by_reference<T1> byRef1;
 		tcl_cast_by_reference<T2> byRef2;
 		tcl_cast_by_reference<T3> byRef3;
@@ -170,8 +170,8 @@ template <typename R, typename T1, typename T2, typename T3, typename T4, typena
   public:
 	callback8(functor_type f) : f_(f) {}
 
-	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 9);
+	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 9, pol.usage_);
 		tcl_cast_by_reference<T1> byRef1;
 		tcl_cast_by_reference<T2> byRef2;
 		tcl_cast_by_reference<T3> byRef3;
@@ -194,8 +194,8 @@ template <typename R, typename T1, typename T2, typename T3, typename T4, typena
   public:
 	callback9(functor_type f) : f_(f) {}
 
-	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 10);
+	virtual void invoke(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 10, pol.usage_);
 		tcl_cast_by_reference<T1> byRef1;
 		tcl_cast_by_reference<T2> byRef2;
 		tcl_cast_by_reference<T3> byRef3;

--- a/cpptcl/details/methods.h
+++ b/cpptcl/details/methods.h
@@ -43,8 +43,8 @@ template <class C, typename R, typename T1> class method1 : public object_cmd_ba
 	method1(mem_type f) : f_(f), cmem_(false) {}
 	method1(cmem_type f) : cf_(f), cmem_(true) {}
 
-	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 3);
+	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 3, pol.usage_);
 		tcl_cast_by_reference<T1> byRef;
 
 		C *p = static_cast<C *>(pv);
@@ -69,8 +69,8 @@ template <class C, typename R, typename T1, typename T2> class method2 : public 
 	method2(mem_type f) : f_(f), cmem_(false) {}
 	method2(cmem_type f) : cf_(f), cmem_(true) {}
 
-	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 4);
+	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 4, pol.usage_);
 
 		C *p = static_cast<C *>(pv);
 		if (cmem_) {
@@ -94,8 +94,8 @@ template <class C, typename R, typename T1, typename T2, typename T3> class meth
 	method3(mem_type f) : f_(f), cmem_(false) {}
 	method3(cmem_type f) : cf_(f), cmem_(true) {}
 
-	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 5);
+	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 5, pol.usage_);
 
 		C *p = static_cast<C *>(pv);
 		if (cmem_) {
@@ -119,8 +119,8 @@ template <class C, typename R, typename T1, typename T2, typename T3, typename T
 	method4(mem_type f) : f_(f), cmem_(false) {}
 	method4(cmem_type f) : cf_(f), cmem_(true) {}
 
-	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 6);
+	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 6, pol.usage_);
 
 		C *p = static_cast<C *>(pv);
 		if (cmem_) {
@@ -144,8 +144,8 @@ template <class C, typename R, typename T1, typename T2, typename T3, typename T
 	method5(mem_type f) : f_(f), cmem_(false) {}
 	method5(cmem_type f) : cf_(f), cmem_(true) {}
 
-	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 7);
+	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 7, pol.usage_);
 
 		C *p = static_cast<C *>(pv);
 		if (cmem_) {
@@ -169,8 +169,8 @@ template <class C, typename R, typename T1, typename T2, typename T3, typename T
 	method6(mem_type f) : f_(f), cmem_(false) {}
 	method6(cmem_type f) : cf_(f), cmem_(true) {}
 
-	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 8);
+	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 8, pol.usage_);
 
 		C *p = static_cast<C *>(pv);
 		if (cmem_) {
@@ -194,8 +194,8 @@ template <class C, typename R, typename T1, typename T2, typename T3, typename T
 	method7(mem_type f) : f_(f), cmem_(false) {}
 	method7(cmem_type f) : cf_(f), cmem_(true) {}
 
-	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 9);
+	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 9, pol.usage_);
 
 		C *p = static_cast<C *>(pv);
 		if (cmem_) {
@@ -219,8 +219,8 @@ template <class C, typename R, typename T1, typename T2, typename T3, typename T
 	method8(mem_type f) : f_(f), cmem_(false) {}
 	method8(cmem_type f) : cf_(f), cmem_(true) {}
 
-	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 10);
+	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 10, pol.usage_);
 
 		C *p = static_cast<C *>(pv);
 		if (cmem_) {
@@ -244,8 +244,8 @@ template <class C, typename R, typename T1, typename T2, typename T3, typename T
 	method9(mem_type f) : f_(f), cmem_(false) {}
 	method9(cmem_type f) : cf_(f), cmem_(true) {}
 
-	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &) {
-		check_params_no(objc, 11);
+	virtual void invoke(void *pv, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], policies const &pol) {
+		check_params_no(objc, 11, pol.usage_);
 
 		C *p = static_cast<C *>(pv);
 		if (cmem_) {

--- a/doc/goodies.md
+++ b/doc/goodies.md
@@ -79,6 +79,22 @@ i1.create_alias("fun", i2, "otherFun");
 
 The above instruction creates an alias in the interpreter i1, so that whenever the fun command is invoked in it, it will forward the call to the second interpreter, to the otherFun command.  
 
+#### <a name="usage">Usage messages</a>
+
+Normally when you provide too few arguments to a command, you get an uninformative error message `Too few arguments.`. You can provide, alternatively,
+a usage() parameter to def():
+
+```
+i.def("slick_search", slick_search, usage("slick_search boxset lat lon"));
+```
+
+Now if you call "slick_search" with too few parameters, you will get the error "Usage: slick_search boxset lat lon".
+
+This is implemented as a policy function, and does not interfere with other policy arguments:
+```
+i.def("slick_close", slick_close, sink(1).usage("slick_close handle"));
+```
+
 [[prev](callpolicies.md)][[top](README.md)][[next](errors.md)]  
 
 * * *

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,10 @@ add_executable(test6 test6.cc ../cpptcl.cc)
 add_test(test6 test6)
 target_link_libraries(test6 PUBLIC ${TCL_LIBRARY} ${TCL_STUB_LIBRARY})
 
+add_executable(test7 test7.cc ../cpptcl.cc)
+add_test(test7 test7)
+target_link_libraries(test7 PUBLIC ${TCL_LIBRARY} ${TCL_STUB_LIBRARY})
+
 add_executable(test_main test_main.cc ../cpptcl.cc)
 add_test(test_main test_main)
 target_link_libraries(test_main PUBLIC ${TCL_LIBRARY} ${TCL_STUB_LIBRARY})

--- a/test/test1.cc
+++ b/test/test1.cc
@@ -11,6 +11,7 @@
 #define CPPTCL_NO_TCL_STUBS
 #include "cpptcl/cpptcl.h"
 #include <iostream>
+#undef NDEBUG
 #include <assert.h>
 
 using namespace Tcl;

--- a/test/test3.cc
+++ b/test/test3.cc
@@ -12,6 +12,7 @@
 #include "cpptcl/cpptcl.h"
 #include <iostream>
 #include <sstream>
+#undef NDEBUG
 #include <assert.h>
 
 using namespace Tcl;

--- a/test/test4.cc
+++ b/test/test4.cc
@@ -12,8 +12,9 @@
 #include "../cpptcl/cpptcl.h"
 #include <cmath>
 #include <iostream>
-#include <assert.h>
 #include <string.h>
+#undef NDEBUG
+#include <assert.h>
 
 using namespace Tcl;
 

--- a/test/test5.cc
+++ b/test/test5.cc
@@ -11,6 +11,7 @@
 #define CPPTCL_NO_TCL_STUBS
 #include "../cpptcl/cpptcl.h"
 #include <iostream>
+#undef NDEBUG
 #include <assert.h>
 
 using namespace Tcl;

--- a/test/test6.cc
+++ b/test/test6.cc
@@ -11,6 +11,7 @@
 #define CPPTCL_NO_TCL_STUBS
 #include "../cpptcl/cpptcl.h"
 #include <iostream>
+#undef NDEBUG
 #include <assert.h>
 
 using namespace Tcl;

--- a/test/test7.cc
+++ b/test/test7.cc
@@ -1,0 +1,66 @@
+//
+// Copyright (C) 2004-2006, Maciej Sobczak
+// Copyright (C) 2017-2018, FlightAware LLC
+//
+// Permission to copy, use, modify, sell and distribute this software
+// is granted provided this copyright notice appears in all copies.
+// This software is provided "as is" without express or implied
+// warranty, and with no claim as to its suitability for any purpose.
+//
+
+#define CPPTCL_NO_TCL_STUBS
+#include "../cpptcl/cpptcl.h"
+#include <iostream>
+#undef NDEBUG
+#include <assert.h>
+
+using namespace Tcl;
+
+int funv1(int, object const &o) {
+	return o.size();
+}
+
+class C {
+  public:
+	C() {}
+
+	C(int, object const &o) {
+		len_ = o.size();
+	}
+
+	int getLen() const { return len_; }
+
+	int len(int, object const &o) {
+		return o.size();
+	}
+
+	int lenc(int, object const &o) const {
+		interpreter i(o.get_interp(), false);
+		return o.size(i);
+	}
+
+  private:
+	int len_;
+};
+
+void test1() {
+	Tcl_Interp * interp = Tcl_CreateInterp();
+	interpreter i(interp, true);
+	i.def("fun1", funv1, usage("Needs a usage message."));
+
+	try {
+		i.eval("fun1 1");
+		assert(false);
+	} catch (tcl_error const &e) {
+		assert(e.what() == std::string("Usage: Needs a usage message."));
+	}
+}
+
+int main() {
+	try {
+		test1();
+	} catch (std::exception const &e) {
+		std::cerr << "Error: " << e.what() << '\n';
+		exit(-1);
+	}
+}


### PR DESCRIPTION
Adds the ability to have meaningful usage messages when cpptcl commands are called with the wrong number of arguments.

Example: `i.def("slick_search", slick_search, usage("slick_search boxset lat lon"))`

Does require the name of the command in the usage message, because it's not available to the usage() function.