### PR TITLE
Check for how USE_TCL_STUBS is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp /usr/local/opt/tcl-tk/lib/libtcl* /usr/local/lib; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh8.6; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get install -y gcc-7 g++-7; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 70 --slave /usr/bin/g++ g++ /usr/bin/g++-7; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get install -y tcl8.6-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y gcc-7 g++-7; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 70 --slave /usr/bin/g++ g++ /usr/bin/g++-7; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y tcl8.6-dev; fi
   
 script:
   - make
-  - make install
+  - sudo make install
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 
-sudo: true
+sudo: false
 
 os:
   - linux
@@ -13,13 +13,13 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp /usr/local/opt/tcl-tk/lib/libtcl* /usr/local/lib; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -s /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh8.6; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y gcc-7 g++-7; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 70 --slave /usr/bin/g++ g++ /usr/bin/g++-7; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y tcl8.6-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get update -qq; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get install -y gcc-7 g++-7; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 70 --slave /usr/bin/g++ g++ /usr/bin/g++-7; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get install -y tcl8.6-dev; fi
   
 script:
   - make
-  - sudo make install
+  - make install
   - make test

--- a/cpptcl/cpptcl.h
+++ b/cpptcl/cpptcl.h
@@ -11,6 +11,14 @@
 #ifndef CPPTCL_INCLUDED
 #define CPPTCL_INCLUDED
 
+#ifdef _TCL
+#ifndef USE_TCL_STUBS
+#ifndef CPPTCL_NO_TCL_STUBS
+#error "tcl.h header included before cpptcl.h.  Either set USE_TCL_STUBS or set CPPTCL_NO_TCL_STUBS if creating a TCL interpreter."
+#endif
+#endif
+#endif
+
 #include <functional>
 #include <map>
 #include <memory>

--- a/examples/example2.cc
+++ b/examples/example2.cc
@@ -3,7 +3,9 @@
 #include <iostream>
 #include <string>
 
+
 #include "tcl.h"
+#define CPPTCL_NO_TCL_STUBS
 #include "cpptcl/cpptcl.h"
 
 using namespace std;

--- a/examples/example6.cc
+++ b/examples/example6.cc
@@ -2,6 +2,7 @@
 
 #include <iostream>
 
+#define CPPTCL_NO_TCL_STUBS
 #include "tcl.h"
 #include "cpptcl/cpptcl.h"
 


### PR DESCRIPTION
Checks if tcl.h was included first.
I do not know if https://github.com/flightaware/cpptcl/blob/master/doc/compiling.md "Programs that embed TCL with static linkage must define -DCPPTCL_NO_TCL_STUBS to disable TCL's stub mechanism for dynamic loading." is enough of a comment about how linking works.