### PR TITLE
Runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,5 +73,8 @@ install(TARGETS cpptcl_static ARCHIVE DESTINATION lib)
 install(FILES ${HDRS} DESTINATION include/cpptcl)
 install(FILES ${HDRS_DETAILS} DESTINATION include/cpptcl/details)
 
+add_library(cpptcl_runtime SHARED ${cpptcl_SOURCE_DIR}/cpptcl_runtime.c)
+target_link_libraries(cpptcl_runtime ${TCL_LIBRARY})
+
 add_subdirectory(test)
 add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,8 @@ install(TARGETS cpptcl_static ARCHIVE DESTINATION lib)
 install(FILES ${HDRS} DESTINATION include/cpptcl)
 install(FILES ${HDRS_DETAILS} DESTINATION include/cpptcl/details)
 
-add_library(cpptcl_runtime SHARED ${cpptcl_SOURCE_DIR}/cpptcl_runtime.c)
+add_library(cpptcl_runtime STATIC ${cpptcl_SOURCE_DIR}/cpptcl_runtime.c)
+set_property(TARGET cpptcl_runtime PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(cpptcl_runtime ${TCL_LIBRARY})
 
 add_subdirectory(test)

--- a/cpptcl/cpptcl.h
+++ b/cpptcl/cpptcl.h
@@ -38,6 +38,11 @@
 
 #include "tcl.h"
 
+// This function is not part of TCL, but is a useful helper.
+extern "C" {
+    Tcl_Interp * Tcl_CreateInterpWithStubs(const char *version, int exact);
+};
+
 namespace Tcl {
 
 // exception class used for reporting all Tcl errors

--- a/cpptcl_runtime.c
+++ b/cpptcl_runtime.c
@@ -1,0 +1,14 @@
+#include <tcl.h>
+
+Tcl_Interp * Tcl_CreateInterpWithStubs(const char *version, int exact)
+{
+    Tcl_Interp *interp = Tcl_CreateInterp();
+
+    if (Tcl_Init(interp) == TCL_ERROR
+        || Tcl_InitStubs(interp, version, exact) == NULL
+        || Tcl_PkgRequire(interp, "Tcl", version, exact) == NULL) {
+	return NULL;
+    }   
+
+    return interp;
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
 
 add_executable(example2 example2.cc)
-target_link_libraries(example2 PUBLIC cpptcl_static ${TCL_STUB_LIBRARY} ${TCL_LIBRARY})
+target_link_libraries(example2 PUBLIC cpptcl_static cpptcl_runtime ${TCL_STUB_LIBRARY} ${TCL_LIBRARY})
 
 add_executable(example6 example6.cc)
-target_link_libraries(example6 PUBLIC cpptcl_static ${TCL_STUB_LIBRARY} ${TCL_LIBRARY})
+target_link_libraries(example6 PUBLIC cpptcl_static cpptcl_runtime ${TCL_STUB_LIBRARY} ${TCL_LIBRARY})
 
 add_library(libcpptcl_module_two SHARED cpptcl_module_two.cc)
 target_link_libraries(libcpptcl_module_two PUBLIC cpptcl_static ${TCL_STUB_LIBRARY})

--- a/examples/example2.cc
+++ b/examples/example2.cc
@@ -4,8 +4,6 @@
 #include <string>
 
 
-#include "tcl.h"
-#define CPPTCL_NO_TCL_STUBS
 #include "cpptcl/cpptcl.h"
 
 using namespace std;
@@ -14,8 +12,7 @@ using namespace Tcl;
 void hello() { cout << "Hello C++/Tcl!" << endl; }
 
 int main() {
-	Tcl_Interp * interp = Tcl_CreateInterp();
-	Tcl_InitStubs(interp, "8.0", 0);
+	Tcl_Interp * interp = Tcl_CreateInterpWithStubs("8.6", 0);
 	interpreter i(interp, true);
 	i.def("hello", hello);
 

--- a/examples/example6.cc
+++ b/examples/example6.cc
@@ -10,13 +10,10 @@ using namespace std;
 using namespace Tcl;
 
 int main() {
-	Tcl_Interp * interp = Tcl_CreateInterp();
-        // Setup the stubs table pointer. TCL can load any extension with a shared library
-        // and that library will expect stubs support.
-	Tcl_InitStubs(interp, "8.0", 0);
-	interpreter i(interp, true);
+    Tcl_Interp * interp = Tcl_CreateInterpWithStubs("8.6", 0);
+    interpreter i(interp, true);
 
-	int numbers[] = {5, 7, 1, 6, 3, 9, 7};
+    int numbers[] = {5, 7, 1, 6, 3, 9, 7};
 	size_t elems = sizeof(numbers) / sizeof(int);
 
 	object tab;


### PR DESCRIPTION
Add ```Tcl_Interp * Tcl_CreateInterpWithStubs(const char *version, int exact);``` to create TCL
interpreters only using the cpptcl/cpptcl.h header.
This requires a new library cpptcl_runtime if you use this function to create a TCL interpreter in an executable.

The cpptcl library expects users to have USE_TCL_STUBS and to rely only on the stubs library.  This is the desired method for extensions. If you create an interpreter, then the function Tcl_CreateInterpWithStubs can be used to make the correct calls on the TCL library for setup.