### PR TITLE
Explicitly define namespaces in headers instead of relying on include site

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -17,9 +17,9 @@ jobs:
       run: |
         brew update
         brew install tcl-tk || true
-        ls /usr/local
-        ls /usr/local/include
-        ls /usr/local/opt/tcl-tk/include
+        ls -l /usr/local
+        ls -l /usr/local/include
+        ls -l /usr/local/opt/tcl-tk/include
         brew --prefix tcl-tk
         sudo mkdir -p /usr/local
         sudo ln -sf /usr/local/opt/tcl-tk/include /usr/local/include/tcl8.6

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -19,7 +19,7 @@ jobs:
         brew install tcl-tk || true
         sudo mkdir -p /usr/local
         sudo ln -sf /usr/local/opt/tcl-tk/include /usr/local/include/tcl8.6
-        sudo cp /usr/local/opt/tcl-tk/lib/libtcl* /usr/local/lib
+        sudo install /usr/local/opt/tcl-tk/lib/libtcl* /usr/local/lib
         sudo ln -sf /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh
         sudo ln -sf /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh8.6
     - name: make

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -17,7 +17,6 @@ jobs:
       run: |
         brew update
         brew install tcl-tk || true
-        ls -l /usr/local/opt/tcl-tk/include/tcl-tk
         sudo mkdir -p /usr/local
         sudo ln -sf /usr/local/opt/tcl-tk/include/tcl-tk /usr/local/include/tcl8.6
         sudo install /usr/local/opt/tcl-tk/lib/libtcl* /usr/local/lib

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -17,6 +17,10 @@ jobs:
       run: |
         brew update
         brew install tcl-tk || true
+        ls /usr/local
+        ls /usr/local/include
+        ls /usr/local/opt/tcl-tk/include
+        brew --prefix tcl-tk
         sudo mkdir -p /usr/local
         sudo ln -sf /usr/local/opt/tcl-tk/include /usr/local/include/tcl8.6
         sudo install /usr/local/opt/tcl-tk/lib/libtcl* /usr/local/lib

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -17,12 +17,9 @@ jobs:
       run: |
         brew update
         brew install tcl-tk || true
-        ls -l /usr/local
-        ls -l /usr/local/include
-        ls -l /usr/local/opt/tcl-tk/include
-        brew --prefix tcl-tk
+        ls -l /usr/local/opt/tcl-tk/include/tcl-tk
         sudo mkdir -p /usr/local
-        sudo ln -sf /usr/local/opt/tcl-tk/include /usr/local/include/tcl8.6
+        sudo ln -sf /usr/local/opt/tcl-tk/include/tcl-tk /usr/local/include/tcl8.6
         sudo install /usr/local/opt/tcl-tk/lib/libtcl* /usr/local/lib
         sudo ln -sf /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh
         sudo ln -sf /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh8.6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(cpptcl)
 include(cmake/version.cmake)
 load_git_properties(cpptcl ${CMAKE_BINARY_DIR}/generated)
 
-set(CPPTCL_VERSION 2.2.5)
+set(CPPTCL_VERSION 2.2.8)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to Release as none was specified.")

--- a/cpptcl/cpptcl.h
+++ b/cpptcl/cpptcl.h
@@ -110,11 +110,19 @@ void set_result(Tcl_Interp *interp, std::string const &s);
 void set_result(Tcl_Interp *interp, void *p);
 void set_result(Tcl_Interp *interp, object const &o);
 
+}
+
+}
+
 // helper functor for converting Tcl objects to the given type
 #include "cpptcl/details/conversions.h"
 
 // dispatchers able to capture (or ignore) the result
 #include "cpptcl/details/dispatchers.h"
+
+namespace Tcl {
+
+namespace details {
 
 // helper for checking for required number of parameters
 // (throws tcl_error when not met)
@@ -123,7 +131,7 @@ void check_params_no(int objc, int required, const std::string &message);
 // helper for gathering optional params in variadic functions
 object get_var_params(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], int from, policies const &pol);
 
-// the callback_base is used to store callback handlers in a polynorphic map
+// the callback_base is used to store callback handlers in a polymorphic map
 class callback_base {
   public:
 	virtual ~callback_base() {}
@@ -190,6 +198,10 @@ template <class C> class class_handler : public class_handler_base {
 	}
 };
 
+}
+
+}
+
 // factory functions for creating class objects
 #include "cpptcl/details/constructors.h"
 
@@ -201,6 +213,10 @@ template <class C> class class_handler : public class_handler_base {
 
 // helper meta function for figuring appropriate constructor callback
 #include "cpptcl/details/metahelpers.h"
+
+namespace Tcl {
+
+namespace details {
 
 // this class is used to provide the "def" interface for defining
 // class member functions
@@ -444,7 +460,11 @@ class interpreter {
 	bool owner_;
 };
 
+}
+
 #include "cpptcl/cpptcl_object.h"
+
+namespace Tcl {
 
 // the InputIterator should give object& or Tcl_Obj* when dereferenced
 template <class InputIterator> details::result interpreter::eval(InputIterator first, InputIterator last) {
@@ -458,7 +478,7 @@ template <class InputIterator> details::result interpreter::eval(InputIterator f
 	return details::result(interp_);
 }
 
-namespace details {
+}
 
 // additional callback envelopes for variadic functions
 #include "cpptcl/details/callbacks_v.h"
@@ -466,9 +486,10 @@ namespace details {
 // additional method envelopes for variadic methods
 #include "cpptcl/details/methods_v.h"
 
-} // namespace details
 
 #include "cpptcl/details/bind.h"
+
+namespace Tcl {
 
 inline std::ostream & operator<<(std::ostream &os, const object& obj)
 {

--- a/cpptcl/cpptcl_object.h
+++ b/cpptcl/cpptcl_object.h
@@ -8,6 +8,8 @@
 #ifndef CPPTCL_OBJECT_H
 #define CPPTCL_OBJECT_H
 
+namespace Tcl {
+
 class object;
 
 /*
@@ -242,5 +244,7 @@ template <> long object::get<long>(interpreter &i) const;
 template <> char const *object::get<char const *>(interpreter &i) const;
 template <> std::string object::get<std::string>(interpreter &i) const;
 template <> std::vector<char> object::get<std::vector<char>>(interpreter &i) const;
+
+}
 
 #endif /* CPPTCL_OBJECT_H */

--- a/cpptcl/details/bind.h
+++ b/cpptcl/details/bind.h
@@ -1,3 +1,5 @@
+namespace Tcl {
+
 template <typename R, typename T1, typename T2 = void, typename T3 = void, typename T4 = void, typename T5 = void, typename T6 = void, typename T7 = void, typename T8 = void, typename T9 = void> struct Bind {
   private:
 	object cmd_;
@@ -173,3 +175,5 @@ template <typename R> struct Bind<R, void, void, void, void, void, void, void, v
 		return (R)(interpreter::getDefault()->eval(obj));
 	}
 };
+
+}

--- a/cpptcl/details/callbacks.h
+++ b/cpptcl/details/callbacks.h
@@ -13,6 +13,8 @@
 #include <tuple>
 #include <utility>
 
+namespace Tcl { namespace details {
+
 template <typename R> class callback0 : public callback_base {
 	typedef R (*functor_type)();
 
@@ -213,3 +215,7 @@ template <typename R, typename T1, typename T2, typename T3, typename T4, typena
   private:
 	functor_type f_;
 };
+
+}
+
+}

--- a/cpptcl/details/callbacks_v.h
+++ b/cpptcl/details/callbacks_v.h
@@ -10,6 +10,8 @@
 
 // Note: this file is not supposed to be a stand-alone header
 
+namespace Tcl { namespace details {
+
 template <typename R> class callback1<R, object const &> : public callback_base {
 	typedef object const &T1;
 	typedef R (*functor_type)(T1);
@@ -199,3 +201,7 @@ template <typename R, typename T1, typename T2, typename T3, typename T4, typena
   private:
 	functor_type f_;
 };
+
+}
+
+}

--- a/cpptcl/details/constructors.h
+++ b/cpptcl/details/constructors.h
@@ -9,6 +9,7 @@
 //
 
 // Note: this file is not supposed to be a stand-alone header
+namespace Tcl { namespace details {
 
 template <class C, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9> struct construct {
 	static C *doit(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) { return new C(t1, t2, t3, t4, t5, t6, t7, t8, t9); }
@@ -49,3 +50,7 @@ template <class C, typename T1> struct construct<C, T1, void, void, void, void, 
 template <class C> struct construct<C, void, void, void, void, void, void, void, void, void> {
 	static C *doit() { return new C(); }
 };
+
+}
+
+}

--- a/cpptcl/details/conversions.h
+++ b/cpptcl/details/conversions.h
@@ -13,6 +13,7 @@
 // helper functor for converting Tcl objects to the given type
 // (it is a struct instead of function,
 // because I need to partially specialize it)
+namespace Tcl { namespace details {
 
 template <typename T> struct tcl_cast;
 
@@ -65,3 +66,6 @@ template <> struct tcl_cast<char const *> { static char const *from(Tcl_Interp *
 
 template <> struct tcl_cast<object> { static object from(Tcl_Interp *, Tcl_Obj *, bool byReference = false); };
 
+}
+
+}

--- a/cpptcl/details/dispatchers.h
+++ b/cpptcl/details/dispatchers.h
@@ -14,6 +14,8 @@
 // capture its return value
 // further dispatch<void> specialization ignores the res
 
+namespace Tcl { namespace details {
+
 template <typename R> struct dispatch {
 	template <class Functor> static void do_dispatch(Tcl_Interp *interp, Functor f) {
 		R res = f();
@@ -87,3 +89,7 @@ template <> struct dispatch<void> {
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, class Functor> static void do_dispatch(Tcl_Interp *, Functor f, T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) { f(t1, t2, t3, t4, t5, t6, t7, t8, t9); }
 };
+
+}
+
+}

--- a/cpptcl/details/metahelpers.h
+++ b/cpptcl/details/metahelpers.h
@@ -9,6 +9,7 @@
 //
 
 // Note: this file is not supposed to be a stand-alone header
+namespace Tcl { namespace details {
 
 template <class C, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9> struct get_callback_type_for_construct { typedef callback9<C *, T1, T2, T3, T4, T5, T6, T7, T8, T9> type; };
 
@@ -29,3 +30,7 @@ template <class C, typename T1, typename T2> struct get_callback_type_for_constr
 template <class C, typename T1> struct get_callback_type_for_construct<C, T1, void, void, void, void, void, void, void, void> { typedef callback1<C *, T1> type; };
 
 template <class C> struct get_callback_type_for_construct<C, void, void, void, void, void, void, void, void, void> { typedef callback0<C *> type; };
+
+}
+
+}

--- a/cpptcl/details/methods.h
+++ b/cpptcl/details/methods.h
@@ -9,6 +9,7 @@
 //
 
 // Note: this file is not supposed to be a stand-alone header
+namespace Tcl { namespace details {
 
 template <class C, typename R> class method0 : public object_cmd_base {
 	typedef R (C::*mem_type)();
@@ -302,3 +303,7 @@ template <class C, typename R, typename T1, typename T2, typename T3, typename T
 	cmem_type cf_;
 	bool cmem_;
 };
+
+}
+
+}

--- a/cpptcl/details/methods_v.h
+++ b/cpptcl/details/methods_v.h
@@ -9,6 +9,7 @@
 //
 
 // Note: this file is not supposed to be a stand-alone header
+namespace Tcl { namespace details {
 
 template <class C, typename R> class method1<C, R, object const &> : public object_cmd_base {
 	typedef object const &T1;
@@ -261,3 +262,7 @@ template <class C, typename R, typename T1, typename T2, typename T3, typename T
 	cmem_type cf_;
 	bool cmem_;
 };
+
+}
+
+}


### PR DESCRIPTION
The old way was supposedly undefined behavior according to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105707
and began causing the build to fail on GCC 12.2. Explicitly declaring
the namespaces within the headers themselves fixes the build and doesn't
seem like it would have unintended consequences (most of the headers are
private and only included once anyway).

EP-209
