### PR TITLE
update min cmake for tests

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -17,8 +17,8 @@ jobs:
       run: |
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         sudo apt-get update -qq
-        sudo apt-get install -y gcc-7 g++-7
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 70 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+        sudo apt-get install -y gcc-11 g++-11
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 70 --slave /usr/bin/g++ g++ /usr/bin/g++-11
         sudo apt-get install -y tcl8.6-dev
     - name: make
       run: make

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -16,12 +16,12 @@ jobs:
     - name: Install dependencies
       run: |
         brew update
-        brew install tcl-tk@8 || true
+        brew install tcl-tk || true
         sudo mkdir -p /usr/local
-        sudo ln -sf /usr/local/opt/tcl-tk@8/include/tcl-tk /usr/local/include/tcl8.6
-        sudo install /usr/local/opt/tcl-tk@8/lib/libtcl* /usr/local/lib
-        sudo ln -sf /usr/local/opt/tcl-tk@8/bin/tclsh8.6 /usr/local/bin/tclsh
-        sudo ln -sf /usr/local/opt/tcl-tk@8/bin/tclsh8.6 /usr/local/bin/tclsh8.6
+        sudo ln -sf /usr/local/opt/tcl-tk/include/tcl-tk /usr/local/include/tcl8.6
+        sudo install /usr/local/opt/tcl-tk/lib/libtcl* /usr/local/lib
+        sudo ln -sf /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh
+        sudo ln -sf /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh8.6
     - name: make
       run: make
     - name: install

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -16,12 +16,12 @@ jobs:
     - name: Install dependencies
       run: |
         brew update
-        brew install tcl-tk || true
+        brew install tcl-tk@8 || true
         sudo mkdir -p /usr/local
-        sudo ln -sf /usr/local/opt/tcl-tk/include/tcl-tk /usr/local/include/tcl8.6
-        sudo install /usr/local/opt/tcl-tk/lib/libtcl* /usr/local/lib
-        sudo ln -sf /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh
-        sudo ln -sf /usr/local/opt/tcl-tk/bin/tclsh8.6 /usr/local/bin/tclsh8.6
+        sudo ln -sf /usr/local/opt/tcl-tk@8/include/tcl-tk /usr/local/include/tcl8.6
+        sudo install /usr/local/opt/tcl-tk@8/lib/libtcl* /usr/local/lib
+        sudo ln -sf /usr/local/opt/tcl-tk@8/bin/tclsh8.6 /usr/local/bin/tclsh
+        sudo ln -sf /usr/local/opt/tcl-tk@8/bin/tclsh8.6 /usr/local/bin/tclsh8.6
     - name: make
       run: make
     - name: install

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.8)
 
 set(TCL_TCLSH tclsh8.6)
 


### PR DESCRIPTION
This will allow us to continue to build on ubuntu:focal since compatibility with CMake < 3.5 has been removed from CMake.