### PR TITLE
fix: Tcl9 fixes, still compatible with tcl8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 message(INFO " cmake build type ${CMAKE_BUILD_TYPE}")
 
-set(TCLSH_VERSION_STRING, "8.6")
-
 # Determine if cpptcl is built as a subproject (using add_subdirectory)
 # or if it is the master project.
 set(CPPTCL_MASTER_PROJECT OFF)
@@ -38,17 +36,9 @@ endif()
 
 include (CTest)
 
-set(TCL_VERSION_MAJOR "8" CACHE STRING "TCL Major version")
-set(TCL_VERSION_MINOR "6" CACHE STRING "TCL Minor version")
-set(TCL_TCLSH "tclsh${TCL_VERSION_MAJOR}.${TCL_VERSION_MINOR}")
-set(TCL_VER "${TCL_VERSION_MAJOR}.${TCL_VERSION_MINOR}")
-set(TCL_VER_BSD "${TCL_VERSION_MAJOR}${TCL_VERSION_MINOR}")
-
-message(INFO " TCL_VER ${TCL_VER}")
-
-find_path(TCL_INCLUDE_PATH tcl.h PATHS /usr/local/include/tcl${TCL_VER} /usr/local/include /usr/include/tcl${TCL_VER} /usr/include NO_DEFAULT_PATH)
-find_library(TCL_LIBRARY NAMES tcl${TCL_VER} tcl${TCL_VER_BSD} PATHS /usr/local/lib /usr/lib)
-find_library(TCL_STUB_LIBRARY NAMES tclstub${TCL_VER} tclstub${TCL_VER_BSD} PATHS /usr/local/lib /usr/lib)
+find_package(TCL)
+find_package(TclStub)
+find_package(Tclsh)
 
 message(INFO " Tcl include ${TCL_INCLUDE_PATH}")
 message(INFO " Tcl library ${TCL_LIBRARY}")

--- a/COMMONmakefile
+++ b/COMMONmakefile
@@ -3,7 +3,7 @@ CPPTCL_LIBRARY = build/libcpptcl.so
 all: $(CPPTCL_LIBRARY) 
 
 build/Makefile: CMakeLists.txt
-	(mkdir -p build; cd build; cmake -DTCL_VERSION_MINOR:STRING=$${TCL_VERSION_MINOR:-6} ..)
+	(mkdir -p build; cd build; ..)
 
 debug: CMakeLists.txt
 	(mkdir -p build; cd build; cmake -DCMAKE_BUILD_TYPE=Debug ..)

--- a/COMMONmakefile
+++ b/COMMONmakefile
@@ -3,7 +3,7 @@ CPPTCL_LIBRARY = build/libcpptcl.so
 all: $(CPPTCL_LIBRARY) 
 
 build/Makefile: CMakeLists.txt
-	(mkdir -p build; cd build; ..)
+	(mkdir -p build; cd build; cmake ..)
 
 debug: CMakeLists.txt
 	(mkdir -p build; cd build; cmake -DCMAKE_BUILD_TYPE=Debug ..)

--- a/test/test1.cc
+++ b/test/test1.cc
@@ -26,7 +26,9 @@ int fun5(char const *s) { return std::string(s).size(); }
 void test1() {
 	Tcl_Interp * interp = Tcl_CreateInterp();
 	interpreter i(interp, true);
+#if (TCL_MAJOR_VERSION < 9)
 	i.make_safe();
+#endif
 
 	std::string s = i.eval("return \"ala ma kota\"");
 	assert(s == "ala ma kota");


### PR DESCRIPTION
* Replace multiple tests and macros with build-n cmake modules to determine TCL file paths.
* Fix tests.